### PR TITLE
example/showenv image needs to write to /opt/data

### DIFF
--- a/images/example.showenv/manifest.json
+++ b/images/example.showenv/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "example/showenv",
   "labels": [
-    { "name": "version", "value": "1.2.0" }
+    { "name": "version", "value": "1.2.1" }
   ],
   "app": {
     "exec": [
@@ -14,7 +14,7 @@
     "user": "games",
     "group": "guest",
     "eventHandlers": [
-      { "name": "pre-start", "exec": [ "/bin/sh", "-c", "id > /opt/data/pre-start-id.txt" ] },
+      { "name": "pre-start", "exec": [ "/bin/sh", "-c", "id > /opt/data/pre-start-id.txt; chown games /opt/data" ] },
       { "name": "post-stop", "exec": [ "/bin/sh", "-c", "id > /opt/data/post-stop-id.txt" ] }
     ],
     "workingDirectory": "/opt/data",


### PR DESCRIPTION
Otherwise /usr/local/bin/showenv.sh fails with permission errors
and works only when started as root from the console